### PR TITLE
Make it compatible with Psych 4

### DIFF
--- a/ext/libv8-node/location.rb
+++ b/ext/libv8-node/location.rb
@@ -18,7 +18,11 @@ module Libv8::Node
 
     def self.load!
       File.open(Pathname(__FILE__).dirname.join('.location.yml')) do |f|
-        YAML.load(f) # rubocop:disable Security/YAMLLoad
+        if YAML.respond_to?(:unsafe_load)
+          YAML.unsafe_load(f)
+        else
+          YAML.load(f) # rubocop:disable Security/YAMLLoad
+        end
       end
     end
 


### PR DESCRIPTION
Psych 4 introduced a breaking change to `YAML.load` https://github.com/ruby/psych/pull/487, which is replacing the implementation of `YAML.load` with `YAML.safe_load`. To make this code work after that change, we need to explicitly call `YAML.unsafe_load` here.